### PR TITLE
Directive just positive

### DIFF
--- a/src/app/directives/to-positive-number.directive.mock.ts
+++ b/src/app/directives/to-positive-number.directive.mock.ts
@@ -3,11 +3,11 @@ const mockNotValidTarget = { value: 'm'};
 
 export const Mock = {
    mock_9: () => ({
-    currentTarget: { ...mockValidTarget },
+    target: { ...mockValidTarget },
     key: '9'
   }),
   mock_M: () => ({
-    currentTarget: { ...mockNotValidTarget },
+    target: { ...mockNotValidTarget },
     key: 'm',
     preventDefault: () => false
   })

--- a/src/app/directives/to-positive-number.directive.spec.ts
+++ b/src/app/directives/to-positive-number.directive.spec.ts
@@ -18,13 +18,13 @@ describe('ToPositiveNumberDirective', () => {
     eventMock = Mock.mock_9();
     expected = Mock.mock_9();
     directive['numberPositive'](eventMock);
-    expect(eventMock.currentTarget.value).toBe(expected.currentTarget.value);
+    expect(eventMock.target.value).toBe(expected.target.value);
   } );
 
   it('should does not accept non-number keys', () => {
     eventMock = Mock.mock_M();
     expected = Mock.mock_M();
     directive['numberPositive'](eventMock);
-    expect(eventMock.currentTarget.value).not.toBe(expected.currentTarget.value);
+    expect(eventMock.target.value).not.toBe(expected.target.value);
   });
 });

--- a/src/app/directives/to-positive-number.directive.ts
+++ b/src/app/directives/to-positive-number.directive.ts
@@ -4,23 +4,29 @@ import { Directive, HostListener } from '@angular/core';
   selector: '[appToPositiveNumber]'
 })
 export class ToPositiveNumberDirective {
-
   private lastValue: any;
 
   @HostListener( 'keyup', [ '$event' ] )
   numberPositive( ev: any ) {
     if (!this.isValidKey(ev.key)) {
-      ev.currentTarget.value = this.lastValue;
-      ev.preventDefault();
-      return false;
+      ev.target.value = this.lastValue;
     } else {
-      this.lastValue = ev.currentTarget.value;
+      this.lastValue = ev.target.value;
     }
   }
 
   @HostListener( 'paste', [ '$event' ] )
-  blockPaste( ev: any  ) {
-    ev.preventDefault();
+  async blockPaste( ev: any  ) {
+    const clipboardValue: any = await navigator['clipboard'].readText();
+    const mockIt0 = {
+      target: ev.target,
+      key: clipboardValue
+    };
+    if (!isNaN(clipboardValue)) {
+      this.numberPositive(mockIt0);
+    } else {
+      ev.preventDefault();
+    }
   }
 
   private isValidKey( key: string ): boolean {


### PR DESCRIPTION
I remove the mock of apptopositivenumberdirective because in the tests cases we don't need it.
I have eliminated the mock because it is not necessary for the tests, now the directive blocks any event issued by keydown and paste that in its value contains non-numeric values